### PR TITLE
refactor: standardize function definitions and documentation

### DIFF
--- a/gallery/src/index.ts
+++ b/gallery/src/index.ts
@@ -10,6 +10,9 @@ import { clean } from './modules/clean';
 import { init } from './modules/init';
 import { thumbnails } from './modules/thumbnails';
 
+/**
+ * CLI program instance used to register all commands.
+ */
 const program = new Command();
 
 program
@@ -20,7 +23,13 @@ program
   .option('-q, --quiet', 'Minimal output (only warnings/errors)', false)
   .showHelpAfterError(true);
 
-const createConsolaUI = (globalOpts: ReturnType<typeof program.opts>): ConsolaInstance => {
+/**
+ * Create a Consola UI instance configured according to the global options.
+ *
+ * @param globalOpts - Global options parsed by commander.
+ * @returns A configured Consola instance.
+ */
+function createConsolaUI(globalOpts: ReturnType<typeof program.opts>): ConsolaInstance {
   let level = LogLevels.info;
 
   if (globalOpts.quiet) {
@@ -32,12 +41,16 @@ const createConsolaUI = (globalOpts: ReturnType<typeof program.opts>): ConsolaIn
   return createConsola({
     level,
   }).withTag('simple-photo-gallery');
-};
+}
 
-// Wrap handlers so they receive (opts, ui)
-const withConsolaUI =
-  <O>(handler: (opts: O, ui: ConsolaInstance) => Promise<void> | void) =>
-  async (opts: O) => {
+/**
+ * Wrap a command handler so that it receives the Consola UI instance.
+ *
+ * @param handler - Command handler to wrap.
+ * @returns A new handler that injects the Consola UI instance.
+ */
+function withConsolaUI<O>(handler: (opts: O, ui: ConsolaInstance) => Promise<void> | void) {
+  return async function wrappedHandler(opts: O) {
     const ui = createConsolaUI(program.opts());
     try {
       await handler(opts, ui);
@@ -47,6 +60,7 @@ const withConsolaUI =
       process.exitCode = 1;
     }
   };
+}
 
 program
   .command('init')

--- a/gallery/src/modules/build/index.ts
+++ b/gallery/src/modules/build/index.ts
@@ -11,13 +11,26 @@ import { processGalleryThumbnails } from '../thumbnails';
 
 import type { BuildOptions } from './types';
 
-function checkFileIsOneFolderUp(filePath: string) {
+/**
+ * Check whether a file resides one directory above the current folder.
+ *
+ * @param filePath - Path to check.
+ * @returns `true` if the path points one folder up.
+ */
+function checkFileIsOneFolderUp(filePath: string): boolean {
   const normalizedPath = path.normalize(filePath);
   const pathParts = normalizedPath.split(path.sep);
   return pathParts.length === 2 && pathParts[0] === '..';
 }
 
-function copyPhotos(galleryData: GalleryData, galleryDir: string, ui: ConsolaInstance) {
+/**
+ * Copy photo files into the gallery directory when needed.
+ *
+ * @param galleryData - Parsed gallery data.
+ * @param galleryDir - Directory containing the gallery.
+ * @param ui - Consola instance for logging.
+ */
+function copyPhotos(galleryData: GalleryData, galleryDir: string, ui: ConsolaInstance): void {
   for (const section of galleryData.sections) {
     for (const image of section.images) {
       if (!checkFileIsOneFolderUp(image.path)) {
@@ -32,7 +45,20 @@ function copyPhotos(galleryData: GalleryData, galleryDir: string, ui: ConsolaIns
   }
 }
 
-async function buildGallery(galleryDir: string, templateDir: string, ui: ConsolaInstance, baseUrl?: string) {
+/**
+ * Build a single gallery by generating thumbnails and running the template.
+ *
+ * @param galleryDir - Directory containing the gallery.
+ * @param templateDir - Directory with the Astro template.
+ * @param ui - Consola instance for logging.
+ * @param baseUrl - Optional base URL for hosted photos.
+ */
+async function buildGallery(
+  galleryDir: string,
+  templateDir: string,
+  ui: ConsolaInstance,
+  baseUrl?: string,
+): Promise<void> {
   ui.start(`Building gallery ${galleryDir}`);
 
   // Generate the thumbnails if needed
@@ -96,6 +122,12 @@ async function buildGallery(galleryDir: string, templateDir: string, ui: Consola
   ui.success(`Gallery built successfully`);
 }
 
+/**
+ * Build command implementation.
+ *
+ * @param options - Command options.
+ * @param ui - Consola instance for logging.
+ */
 export async function build(options: BuildOptions, ui: ConsolaInstance): Promise<void> {
   try {
     // Find all gallery directories

--- a/gallery/src/modules/build/types/index.ts
+++ b/gallery/src/modules/build/types/index.ts
@@ -1,5 +1,11 @@
+/**
+ * Options for the `build` command.
+ */
 export interface BuildOptions {
+  /** Path to the gallery directory. */
   gallery: string;
+  /** Whether to scan subdirectories recursively. */
   recursive: boolean;
+  /** Optional base URL where photos are hosted. */
   baseUrl?: string;
 }

--- a/gallery/src/modules/build/utils/index.ts
+++ b/gallery/src/modules/build/utils/index.ts
@@ -1,9 +1,16 @@
 import path from 'node:path';
 
-// __dirname workaround for ESM modules
+/**
+ * Directory name of the current module (ESM workaround).
+ */
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
-// Helper function to resolve paths relative to current file
-export const resolveFromCurrentDir = (...segments: string[]): string => {
+/**
+ * Resolve a path relative to the current directory.
+ *
+ * @param segments - Path segments to resolve.
+ * @returns Resolved absolute path.
+ */
+export function resolveFromCurrentDir(...segments: string[]): string {
   return path.resolve(__dirname, ...segments);
-};
+}

--- a/gallery/src/modules/clean/index.ts
+++ b/gallery/src/modules/clean/index.ts
@@ -7,9 +7,10 @@ import type { CleanOptions } from './types';
 import type { ConsolaInstance } from 'consola';
 
 /**
- * Clean gallery files from a single directory
- * @param galleryDir - Directory containing a gallery
- * @param ui - Consola instance for logging
+ * Clean gallery files from a single directory.
+ *
+ * @param galleryDir - Directory containing a gallery.
+ * @param ui - Consola instance for logging.
  */
 async function cleanGallery(galleryDir: string, ui: ConsolaInstance): Promise<void> {
   let filesRemoved = 0;
@@ -46,8 +47,11 @@ async function cleanGallery(galleryDir: string, ui: ConsolaInstance): Promise<vo
 }
 
 /**
- * Clean command implementation
- * Removes all gallery-related files and directories
+ * Clean command implementation.
+ * Removes all gallery-related files and directories.
+ *
+ * @param options - Command options.
+ * @param ui - Consola instance for logging.
  */
 export async function clean(options: CleanOptions, ui: ConsolaInstance): Promise<void> {
   try {

--- a/gallery/src/modules/clean/types/index.ts
+++ b/gallery/src/modules/clean/types/index.ts
@@ -1,4 +1,9 @@
+/**
+ * Options for the `clean` command.
+ */
 export interface CleanOptions {
+  /** Path to the gallery directory. */
   gallery: string;
+  /** Whether to scan subdirectories recursively. */
   recursive: boolean;
 }

--- a/gallery/src/modules/init/const/index.ts
+++ b/gallery/src/modules/init/const/index.ts
@@ -1,5 +1,29 @@
-// Image extensions
-export const IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp', '.tiff', '.tif', '.svg']);
+/**
+ * Supported image file extensions.
+ */
+export const IMAGE_EXTENSIONS = new Set([
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.gif',
+  '.bmp',
+  '.webp',
+  '.tiff',
+  '.tif',
+  '.svg',
+]);
 
-// Video extensions
-export const VIDEO_EXTENSIONS = new Set(['.mp4', '.avi', '.mov', '.wmv', '.flv', '.webm', '.mkv', '.m4v', '.3gp']);
+/**
+ * Supported video file extensions.
+ */
+export const VIDEO_EXTENSIONS = new Set([
+  '.mp4',
+  '.avi',
+  '.mov',
+  '.wmv',
+  '.flv',
+  '.webm',
+  '.mkv',
+  '.m4v',
+  '.3gp',
+]);

--- a/gallery/src/modules/init/index.ts
+++ b/gallery/src/modules/init/index.ts
@@ -7,6 +7,13 @@ import type { GallerySettingsFromUser, ProcessDirectoryResult, ScanDirectoryResu
 import type { MediaFile } from '../../types';
 import type { ConsolaInstance } from 'consola';
 
+/**
+ * Scan a directory for media files and sub-galleries.
+ *
+ * @param dirPath - Path to scan.
+ * @param ui - Consola instance for logging.
+ * @returns Media files and sub-gallery directories found in the path.
+ */
 async function scanDirectory(dirPath: string, ui: ConsolaInstance): Promise<ScanDirectoryResult> {
   const mediaFiles: MediaFile[] = [];
   const subGalleryDirectories: string[] = [];
@@ -48,6 +55,14 @@ async function scanDirectory(dirPath: string, ui: ConsolaInstance): Promise<Scan
   return { mediaFiles, subGalleryDirectories };
 }
 
+/**
+ * Prompt the user for gallery settings.
+ *
+ * @param galleryName - Name of the gallery folder.
+ * @param defaultImage - Default header image.
+ * @param ui - Consola instance for interaction.
+ * @returns Settings provided by the user.
+ */
 async function getGallerySettingsFromUser(
   galleryName: string,
   defaultImage: string,
@@ -90,6 +105,15 @@ async function getGallerySettingsFromUser(
   return { title, description, headerImage, thumbnailSize };
 }
 
+/**
+ * Create the `gallery.json` file with provided media and sub-galleries.
+ *
+ * @param mediaFiles - Media files discovered in the directory.
+ * @param galleryJsonPath - Path where `gallery.json` will be written.
+ * @param subGalleries - Optional sub-galleries.
+ * @param useDefaultSettings - Whether to use default settings without user prompts.
+ * @param ui - Consola instance for logging.
+ */
 async function createGalleryJson(
   mediaFiles: MediaFile[],
   galleryJsonPath: string,
@@ -142,6 +166,16 @@ async function createGalleryJson(
   await fs.writeFile(galleryJsonPath, JSON.stringify(galleryData, null, 2));
 }
 
+/**
+ * Recursively process a directory tree and generate `gallery.json` files.
+ *
+ * @param scanPath - Path to scan for media files.
+ * @param outputPath - Output directory where galleries will be created.
+ * @param recursive - Whether to process subdirectories recursively.
+ * @param useDefaultSettings - Use default gallery settings without prompts.
+ * @param ui - Consola instance for logging.
+ * @returns Aggregated processing result.
+ */
 async function processDirectory(
   scanPath: string,
   outputPath: string,
@@ -217,6 +251,12 @@ async function processDirectory(
   return result;
 }
 
+/**
+ * Init command implementation.
+ *
+ * @param options - Command options.
+ * @param ui - Consola instance for logging.
+ */
 export async function init(options: ScanOptions, ui: ConsolaInstance): Promise<void> {
   try {
     const scanPath = path.resolve(options.photos);

--- a/gallery/src/modules/init/types/index.ts
+++ b/gallery/src/modules/init/types/index.ts
@@ -1,34 +1,68 @@
 import type { MediaFile } from '../../../types';
 
+/**
+ * Type representing supported media file types.
+ */
 export type MediaFileType = 'image' | 'video';
 
+/**
+ * Options for the `init` command.
+ */
 export interface ScanOptions {
+  /** Path to the folder containing the photos. */
   photos: string;
+  /** Optional path where the gallery will be initialized. */
   gallery?: string;
+  /** Whether to scan subdirectories recursively. */
   recursive: boolean;
+  /** Use default gallery settings instead of prompting the user. */
   default: boolean;
 }
 
+/**
+ * Description of a generated sub‑gallery.
+ */
 export interface SubGallery {
+  /** Title of the sub-gallery. */
   title: string;
+  /** Path to the header image. */
   headerImage: string;
+  /** Relative path to the sub-gallery directory. */
   path: string;
 }
 
+/**
+ * Result of scanning a single directory for media files and sub-galleries.
+ */
 export interface ScanDirectoryResult {
+  /** Found media files. */
   mediaFiles: MediaFile[];
+  /** Directories containing potential sub-galleries. */
   subGalleryDirectories: string[];
 }
 
+/**
+ * Aggregated result of processing a directory tree.
+ */
 export interface ProcessDirectoryResult {
+  /** Total number of media files found. */
   totalFiles: number;
+  /** Total number of galleries created. */
   totalGalleries: number;
+  /** Optional sub-gallery generated for the directory. */
   subGallery?: SubGallery;
 }
 
+/**
+ * Gallery settings entered by the user.
+ */
 export interface GallerySettingsFromUser {
+  /** Title for the gallery. */
   title: string;
+  /** Description of the gallery. */
   description: string;
+  /** Header image path. */
   headerImage: string;
+  /** Size of generated thumbnails in pixels. */
   thumbnailSize: number;
 }

--- a/gallery/src/modules/init/types/node-ffprobe.d.ts
+++ b/gallery/src/modules/init/types/node-ffprobe.d.ts
@@ -1,17 +1,35 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 declare module 'node-ffprobe' {
+  /**
+   * Video or audio stream information returned by ffprobe.
+   */
   export interface Stream {
+    /** Type of the stream, e.g. `video` or `audio`. */
     codec_type: string;
+    /** Width of the video stream in pixels. */
     width?: number;
+    /** Height of the video stream in pixels. */
     height?: number;
+    /** Additional metadata provided by ffprobe. */
     [key: string]: any;
   }
 
+  /**
+   * Result returned by the ffprobe call.
+   */
   export interface ProbeResult {
+    /** All streams discovered in the file. */
     streams: Stream[];
+    /** General file format information. */
     format: any;
   }
 
+  /**
+   * Inspect a media file using ffprobe.
+   *
+   * @param filePath - Path to the media file.
+   * @returns Promise resolving with the ffprobe result.
+   */
   export default function ffprobe(filePath: string): Promise<ProbeResult>;
 }

--- a/gallery/src/modules/init/utils/index.ts
+++ b/gallery/src/modules/init/utils/index.ts
@@ -4,6 +4,12 @@ import { IMAGE_EXTENSIONS, VIDEO_EXTENSIONS } from '../const';
 
 import type { MediaFileType } from '../types';
 
+/**
+ * Determine the media file type based on its file extension.
+ *
+ * @param fileName - Name of the file to inspect.
+ * @returns `image`, `video` or `null` if the extension is unsupported.
+ */
 export function getMediaFileType(fileName: string): MediaFileType | null {
   const ext = path.extname(fileName).toLowerCase();
   if (IMAGE_EXTENSIONS.has(ext)) return 'image';
@@ -11,6 +17,12 @@ export function getMediaFileType(fileName: string): MediaFileType | null {
   return null;
 }
 
+/**
+ * Convert a folder name into a human‑readable title.
+ *
+ * @param folderName - Folder name to convert.
+ * @returns Capitalized title suitable for display.
+ */
 export function capitalizeTitle(folderName: string): string {
   return folderName
     .replace('-', ' ')

--- a/gallery/src/modules/thumbnails/index.ts
+++ b/gallery/src/modules/thumbnails/index.ts
@@ -11,6 +11,15 @@ import { findGalleries, handleFileProcessingError } from '../../utils';
 
 import type { ThumbnailOptions } from './types';
 
+/**
+ * Process an image file and create its thumbnail if needed.
+ *
+ * @param imagePath - Path to the original image.
+ * @param thumbnailPath - Path where the thumbnail will be stored.
+ * @param thumbnailSize - Desired thumbnail height in pixels.
+ * @param lastMediaTimestamp - Timestamp of the last processed media file.
+ * @returns Updated media file or `undefined` if processing was skipped.
+ */
 async function processImage(
   imagePath: string,
   thumbnailPath: string,
@@ -61,6 +70,16 @@ async function processImage(
   };
 }
 
+/**
+ * Process a video file and generate its thumbnail if necessary.
+ *
+ * @param videoPath - Path to the video file.
+ * @param thumbnailPath - Path where the thumbnail will be stored.
+ * @param thumbnailSize - Desired thumbnail height in pixels.
+ * @param verbose - Whether to enable verbose ffmpeg output.
+ * @param lastMediaTimestamp - Timestamp of the last processed media file.
+ * @returns Updated media file or `undefined` if processing was skipped.
+ */
 async function processVideo(
   videoPath: string,
   thumbnailPath: string,
@@ -97,6 +116,16 @@ async function processVideo(
   };
 }
 
+/**
+ * Process a single media file (image or video) and update its metadata.
+ *
+ * @param mediaFile - Media file to process.
+ * @param galleryDir - Directory containing the gallery.
+ * @param thumbnailsPath - Directory where thumbnails are stored.
+ * @param thumbnailSize - Desired thumbnail height in pixels.
+ * @param ui - Consola instance for logging.
+ * @returns The updated media file.
+ */
 async function processMediaFile(
   mediaFile: MediaFile,
   galleryDir: string,
@@ -142,7 +171,14 @@ async function processMediaFile(
   }
 }
 
-export const processGalleryThumbnails = async (galleryDir: string, ui: ConsolaInstance): Promise<number> => {
+/**
+ * Create thumbnails for all media files in a single gallery directory.
+ *
+ * @param galleryDir - Directory containing the gallery.
+ * @param ui - Consola instance for logging.
+ * @returns Number of processed media files.
+ */
+export async function processGalleryThumbnails(galleryDir: string, ui: ConsolaInstance): Promise<number> {
   const galleryJsonPath = path.join(galleryDir, 'gallery', 'gallery.json');
   const thumbnailsPath = path.join(galleryDir, 'gallery', 'thumbnails');
 
@@ -160,7 +196,13 @@ export const processGalleryThumbnails = async (galleryDir: string, ui: ConsolaIn
     let processedCount = 0;
     for (const section of galleryData.sections) {
       for (const [index, mediaFile] of section.images.entries()) {
-        section.images[index] = await processMediaFile(mediaFile, galleryDir, thumbnailsPath, galleryData.thumbnailSize, ui);
+        section.images[index] = await processMediaFile(
+          mediaFile,
+          galleryDir,
+          thumbnailsPath,
+          galleryData.thumbnailSize,
+          ui,
+        );
       }
 
       processedCount += section.images.length;
@@ -176,8 +218,14 @@ export const processGalleryThumbnails = async (galleryDir: string, ui: ConsolaIn
     ui.error(`Error creating thumbnails for ${galleryDir}`);
     throw error;
   }
-};
+}
 
+/**
+ * Thumbnail command implementation.
+ *
+ * @param options - Command line options.
+ * @param ui - Consola instance for logging.
+ */
 export async function thumbnails(options: ThumbnailOptions, ui: ConsolaInstance): Promise<void> {
   try {
     // Find all gallery directories

--- a/gallery/src/modules/thumbnails/types/index.ts
+++ b/gallery/src/modules/thumbnails/types/index.ts
@@ -1,9 +1,19 @@
+/**
+ * Options for the `thumbnails` command.
+ */
 export interface ThumbnailOptions {
+  /** Path to the gallery directory. */
   gallery: string;
+  /** Whether to scan subdirectories recursively. */
   recursive: boolean;
 }
 
+/**
+ * Generic width/height dimensions.
+ */
 export interface Dimensions {
+  /** Width in pixels. */
   width: number;
+  /** Height in pixels. */
   height: number;
 }

--- a/gallery/src/modules/thumbnails/utils/index.ts
+++ b/gallery/src/modules/thumbnails/utils/index.ts
@@ -9,16 +9,35 @@ import type { Dimensions } from '../types';
 import type { Buffer } from 'node:buffer';
 import type { Metadata, Sharp } from 'sharp';
 
+/**
+ * Get the modification time of a file.
+ *
+ * @param filePath - Path to the file.
+ * @returns Modification time of the file.
+ */
 export async function getFileMtime(filePath: string): Promise<Date> {
   const stats = await fs.stat(filePath);
   return stats.mtime;
 }
 
-// Utility function to resize and save thumbnail
+/**
+ * Resize an image and save it as a thumbnail.
+ *
+ * @param image - Sharp instance of the image.
+ * @param outputPath - Path where the thumbnail will be saved.
+ * @param width - Width of the thumbnail.
+ * @param height - Height of the thumbnail.
+ */
 async function resizeAndSaveThumbnail(image: Sharp, outputPath: string, width: number, height: number): Promise<void> {
   await image.resize(width, height, { withoutEnlargement: true }).jpeg({ quality: 90 }).toFile(outputPath);
 }
 
+/**
+ * Extract an image description from EXIF metadata if available.
+ *
+ * @param metadata - Metadata object from Sharp.
+ * @returns Description string or `undefined` if not found.
+ */
 export async function getImageDescription(metadata: Metadata): Promise<string | undefined> {
   let description: string | undefined;
 
@@ -39,6 +58,15 @@ export async function getImageDescription(metadata: Metadata): Promise<string | 
   return description;
 }
 
+/**
+ * Create a thumbnail for an image.
+ *
+ * @param image - Sharp instance of the image.
+ * @param metadata - Metadata for the image.
+ * @param outputPath - Path where the thumbnail will be saved.
+ * @param height - Desired thumbnail height.
+ * @returns Dimensions of the created thumbnail.
+ */
 export async function createImageThumbnail(
   image: Sharp,
   metadata: Metadata,
@@ -64,6 +92,12 @@ export async function createImageThumbnail(
   return { width, height };
 }
 
+/**
+ * Retrieve the dimensions of a video file using ffprobe.
+ *
+ * @param filePath - Path to the video file.
+ * @returns Video dimensions.
+ */
 export async function getVideoDimensions(filePath: string): Promise<Dimensions> {
   const data = await ffprobe(filePath);
   const videoStream = data.streams.find((stream) => stream.codec_type === 'video');
@@ -84,6 +118,16 @@ export async function getVideoDimensions(filePath: string): Promise<Dimensions> 
   return dimensions;
 }
 
+/**
+ * Create a thumbnail for a video file using ffmpeg and sharp.
+ *
+ * @param inputPath - Path to the video file.
+ * @param videoDimensions - Dimensions of the source video.
+ * @param outputPath - Path where the thumbnail will be saved.
+ * @param height - Desired thumbnail height.
+ * @param verbose - Whether to output ffmpeg logs.
+ * @returns Dimensions of the created thumbnail.
+ */
 export async function createVideoThumbnail(
   inputPath: string,
   videoDimensions: Dimensions,

--- a/gallery/src/types/index.ts
+++ b/gallery/src/types/index.ts
@@ -1,49 +1,104 @@
 import { z } from 'zod';
 
+/**
+ * Schema describing a generated thumbnail image.
+ */
 export const ThumbnailSchema = z.object({
+  /** Path to the thumbnail file. */
   path: z.string(),
+  /** Width of the thumbnail in pixels. */
   width: z.number(),
+  /** Height of the thumbnail in pixels. */
   height: z.number(),
 });
 
+/**
+ * Schema describing a media file within the gallery.
+ */
 export const MediaFileSchema = z.object({
+  /** Type of the media file. */
   type: z.enum(['image', 'video']),
+  /** Path to the media file. */
   path: z.string(),
+  /** Optional alternative text. */
   alt: z.string().optional(),
+  /** Width of the media file in pixels. */
   width: z.number(),
+  /** Height of the media file in pixels. */
   height: z.number(),
+  /** Optional thumbnail information. */
   thumbnail: ThumbnailSchema.optional(),
+  /** Timestamp of the last processed media file. */
   lastMediaTimestamp: z.string().optional(),
 });
 
+/**
+ * Schema for a gallery section grouping media files.
+ */
 export const GallerySectionSchema = z.object({
+  /** Optional section title. */
   title: z.string().optional(),
+  /** Optional section description. */
   description: z.string().optional(),
+  /** Media files contained in the section. */
   images: z.array(MediaFileSchema),
 });
 
+/**
+ * Schema describing a sub-gallery entry.
+ */
 export const SubGallerySchema = z.object({
+  /** Title of the sub-gallery. */
   title: z.string(),
+  /** Path to the header image. */
   headerImage: z.string(),
+  /** Relative path to the sub-gallery. */
   path: z.string(),
 });
 
+/**
+ * Schema for the entire gallery configuration.
+ */
 export const GalleryDataSchema = z.object({
+  /** Title of the gallery. */
   title: z.string(),
+  /** Description of the gallery. */
   description: z.string(),
+  /** Header image path. */
   headerImage: z.string(),
+  /** Size of thumbnails. */
   thumbnailSize: z.number(),
+  /** Additional metadata. */
   metadata: z.object({
     ogUrl: z.string(),
   }),
+  /** Optional output path for the built gallery. */
   galleryOutputPath: z.string().optional(),
+  /** Optional base URL for media files. */
   mediaBaseUrl: z.string().optional(),
+  /** Sections of the gallery. */
   sections: z.array(GallerySectionSchema),
+  /** Sub-galleries information. */
   subGalleries: z.object({ title: z.string(), galleries: z.array(SubGallerySchema) }),
 });
 
+/**
+ * Thumbnail type derived from {@link ThumbnailSchema}.
+ */
 export type Thumbnail = z.infer<typeof ThumbnailSchema>;
+/**
+ * Media file type derived from {@link MediaFileSchema}.
+ */
 export type MediaFile = z.infer<typeof MediaFileSchema>;
+/**
+ * Gallery section type derived from {@link GallerySectionSchema}.
+ */
 export type GallerySection = z.infer<typeof GallerySectionSchema>;
+/**
+ * Sub-gallery type derived from {@link SubGallerySchema}.
+ */
 export type SubGallery = z.infer<typeof SubGallerySchema>;
+/**
+ * Complete gallery data type derived from {@link GalleryDataSchema}.
+ */
 export type GalleryData = z.infer<typeof GalleryDataSchema>;

--- a/gallery/src/utils/index.ts
+++ b/gallery/src/utils/index.ts
@@ -4,13 +4,13 @@ import path from 'node:path';
 import type { ConsolaInstance } from 'consola';
 
 /**
- * Finds all gallery directories that contain a gallery/gallery.json file.
+ * Find all gallery directories that contain a `gallery/gallery.json` file.
  *
- * @param basePath - The base directory to search from
- * @param recursive - Whether to search subdirectories recursively
- * @returns Array of paths to directories containing gallery/gallery.json files
+ * @param basePath - Base directory to search from.
+ * @param recursive - Whether to search subdirectories recursively.
+ * @returns Array of paths to directories containing gallery JSON files.
  */
-export const findGalleries = (basePath: string, recursive: boolean): string[] => {
+export function findGalleries(basePath: string, recursive: boolean): string[] {
   const galleryDirs: string[] = [];
 
   // Check basePath itself
@@ -36,9 +36,16 @@ export const findGalleries = (basePath: string, recursive: boolean): string[] =>
   }
 
   return galleryDirs;
-};
+}
 
-export const handleFileProcessingError = (error: unknown, filename: string, ui: ConsolaInstance) => {
+/**
+ * Handle errors that occur when processing media files.
+ *
+ * @param error - The error thrown during processing.
+ * @param filename - Name of the file being processed.
+ * @param ui - Consola instance used for logging.
+ */
+export function handleFileProcessingError(error: unknown, filename: string, ui: ConsolaInstance): void {
   if (error instanceof Error && (error.message.includes('ffprobe') || error.message.includes('ffmpeg'))) {
     // Handle ffmpeg error
     ui.warn(
@@ -53,4 +60,4 @@ export const handleFileProcessingError = (error: unknown, filename: string, ui: 
   }
 
   ui.debug(error);
-};
+}


### PR DESCRIPTION
## Summary
- use classic function declarations instead of arrow functions
- document all exported functions, types, interfaces, and constants

## Testing
- `yarn workspace simple-photo-gallery test` *(fails: Clean command tests failing)*
- `yarn workspace simple-photo-gallery lint` *(no output)*
- `yarn workspace simple-photo-gallery compile` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd0d2617c8331a0864ab550fa9d7c