### PR TITLE
Add option to disable scanning for new photos

### DIFF
--- a/docs/commands/build.md
+++ b/docs/commands/build.md
@@ -19,6 +19,7 @@ If you have created the gallery in a different folder from the photos folder, th
 | `-g, --gallery <path>` | Path to gallery directory     | Current directory |
 | `-r, --recursive`      | Build all galleries           | `false`           |
 | `-b, --base-url <url>` | Base URL for external hosting | None              |
+| `--no-scan`            | Do not scan for new photos    | `false`           |
 | `-v, --verbose`        | Show detailed output          |                   |
 | `-q, --quiet`          | Only show warnings/errors     |                   |
 | `-h, --help`           | Show command help             |                   |
@@ -37,4 +38,7 @@ spg build -r
 
 # Build with external base URL (no photo copying) - useful for hosting photos separately from the gallery
 spg build -b https://photos.example.com/
+
+# Build without scanning for new photos
+spg build --no-scan
 ```

--- a/gallery/src/index.ts
+++ b/gallery/src/index.ts
@@ -175,6 +175,7 @@ program
   .option('-g, --gallery <path>', 'Path to the directory of the gallery. Default: current working directory', process.cwd())
   .option('-r, --recursive', 'Scan subdirectories recursively', false)
   .option('-b, --base-url <url>', 'Base URL where the photos are hosted')
+  .option('--no-scan', 'Do not scan for new photos when buildign the gallery', true)
   .action(withCommandContext((options, ui) => build(options, ui)));
 
 program

--- a/gallery/src/modules/build/index.ts
+++ b/gallery/src/modules/build/index.ts
@@ -108,10 +108,17 @@ async function scanAndAppendNewFiles(
  * Builds a single gallery by generating thumbnails and creating HTML output
  * @param galleryDir - Directory containing the gallery
  * @param templateDir - Directory containing the Astro template
+ * @param scan - Whether to scan for new media files
  * @param ui - ConsolaInstance for logging
  * @param baseUrl - Optional base URL for hosting photos
  */
-async function buildGallery(galleryDir: string, templateDir: string, ui: ConsolaInstance, baseUrl?: string): Promise<void> {
+async function buildGallery(
+  galleryDir: string,
+  templateDir: string,
+  scan: boolean,
+  ui: ConsolaInstance,
+  baseUrl?: string,
+): Promise<void> {
   ui.start(`Building gallery ${galleryDir}`);
 
   // Read the gallery.json file
@@ -119,7 +126,9 @@ async function buildGallery(galleryDir: string, templateDir: string, ui: Consola
   let galleryData = parseGalleryJson(galleryJsonPath, ui);
 
   // Scan for new media files and append them to the gallery.json
-  galleryData = await scanAndAppendNewFiles(galleryDir, galleryJsonPath, galleryData, ui);
+  if (scan) {
+    galleryData = await scanAndAppendNewFiles(galleryDir, galleryJsonPath, galleryData, ui);
+  }
 
   const socialMediaCardImagePath = path.join(galleryDir, 'gallery', 'images', 'social-media-card.jpg');
   const mediaBasePath = galleryData.mediaBasePath;
@@ -227,6 +236,7 @@ async function buildGallery(galleryDir: string, templateDir: string, ui: Consola
  * @param ui - ConsolaInstance for logging
  */
 export async function build(options: BuildOptions, ui: ConsolaInstance): Promise<CommandResultSummary> {
+  console.log('DBG: options', options);
   try {
     // Find all gallery directories
     const galleryDirs = findGalleries(options.gallery, options.recursive);
@@ -243,7 +253,7 @@ export async function build(options: BuildOptions, ui: ConsolaInstance): Promise
     let totalGalleries = 0;
     for (const dir of galleryDirs) {
       const baseUrl = options.baseUrl ? `${options.baseUrl}${path.relative(options.gallery, dir)}` : undefined;
-      await buildGallery(path.resolve(dir), themeDir, ui, baseUrl);
+      await buildGallery(path.resolve(dir), themeDir, options.scan, ui, baseUrl);
 
       ++totalGalleries;
     }

--- a/gallery/src/modules/build/types/index.ts
+++ b/gallery/src/modules/build/types/index.ts
@@ -6,4 +6,6 @@ export interface BuildOptions {
   recursive: boolean;
   /** Optional base URL where the photos are hosted */
   baseUrl?: string;
+  /** Scan for new photos */
+  scan: boolean;
 }


### PR DESCRIPTION
This PR adds an option to the build script to disable scanning for new photos