### PR TITLE
Allow using getImageDescription with both a file path and a FIle object

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-photo-gallery",
-  "version": "2.0.11-rc.7",
+  "version": "2.0.11-rc.11",
   "description": "Simple Photo Gallery CLI",
   "license": "MIT",
   "author": "Vladimir Haltakov, Tomasz Rusin",
@@ -26,6 +26,10 @@
     "./lib": {
       "types": "./dist/lib/index.d.ts",
       "default": "./dist/lib/index.js"
+    },
+    "./lib/browser": {
+      "types": "./dist/lib/browser.d.ts",
+      "default": "./dist/lib/browser.js"
     }
   },
   "scripts": {

--- a/gallery/src/lib/browser.ts
+++ b/gallery/src/lib/browser.ts
@@ -1,0 +1,1 @@
+export { getImageDescription } from '../utils/descriptions';

--- a/gallery/src/lib/index.ts
+++ b/gallery/src/lib/index.ts
@@ -11,14 +11,7 @@ export type {
 
 // Re-export utility functions from the CLI
 export { generateBlurHash } from '../utils/blurhash';
-export {
-  loadImage,
-  loadImageWithMetadata,
-  resizeImage,
-  cropAndResizeImage,
-  getImageDescription,
-  createImageThumbnails,
-} from '../utils/image';
+export { loadImage, loadImageWithMetadata, resizeImage, cropAndResizeImage, createImageThumbnails } from '../utils/image';
 export { getVideoDimensions, createVideoThumbnails } from '../utils/video';
 export type { Dimensions, ImageWithMetadata } from '../types';
 

--- a/gallery/src/modules/thumbnails/index.ts
+++ b/gallery/src/modules/thumbnails/index.ts
@@ -8,8 +8,9 @@ import { getFileMtime } from './utils';
 import { DEFAULT_THUMBNAIL_SIZE } from '../../config';
 import { findGalleries, handleFileProcessingError } from '../../utils';
 import { generateBlurHash } from '../../utils/blurhash';
+import { getImageDescription } from '../../utils/descriptions';
 import { parseGalleryJson } from '../../utils/gallery';
-import { getImageDescription, createImageThumbnails, loadImageWithMetadata } from '../../utils/image';
+import { createImageThumbnails, loadImageWithMetadata } from '../../utils/image';
 import { getVideoDimensions, createVideoThumbnails } from '../../utils/video';
 
 import type { ThumbnailOptions } from './types';

--- a/gallery/src/utils/descriptions.ts
+++ b/gallery/src/utils/descriptions.ts
@@ -1,0 +1,42 @@
+import ExifReader from 'exifreader';
+
+/**
+ * Extracts description from image EXIF data
+ * @param image - Image path or File object
+ * @returns Promise resolving to image description or undefined if not found
+ */
+export async function getImageDescription(image: string | File): Promise<string | undefined> {
+  try {
+    const tags = await ExifReader.load(image);
+
+    // Description
+    if (tags.description?.description) return tags.description.description;
+
+    // ImageDescription
+    if (tags.ImageDescription?.description) return tags.ImageDescription.description;
+
+    // UserComment
+    if (
+      tags.UserComment &&
+      typeof tags.UserComment === 'object' &&
+      tags.UserComment !== null &&
+      'description' in tags.UserComment
+    ) {
+      return (tags.UserComment as { description: string }).description;
+    }
+
+    // ExtDescrAccessibility
+    if (tags.ExtDescrAccessibility?.description) return tags.ExtDescrAccessibility.description;
+
+    // Caption/Abstract
+    if (tags['Caption/Abstract']?.description) return tags['Caption/Abstract'].description;
+
+    // XP Title
+    if (tags.XPTitle?.description) return tags.XPTitle.description;
+
+    // XP Comment
+    if (tags.XPComment?.description) return tags.XPComment.description;
+  } catch {
+    return undefined;
+  }
+}

--- a/gallery/src/utils/image.ts
+++ b/gallery/src/utils/image.ts
@@ -1,4 +1,3 @@
-import ExifReader from 'exifreader';
 import sharp from 'sharp';
 
 import type { Dimensions, ImageWithMetadata } from '../types';
@@ -78,47 +77,6 @@ export async function cropAndResizeImage(
     })
     .toFormat(format)
     .toFile(outputPath);
-}
-
-/**
- * Extracts description from image EXIF data
- * @param image - Image path or File object
- * @returns Promise resolving to image description or undefined if not found
- */
-export async function getImageDescription(image: string | File): Promise<string | undefined> {
-  try {
-    const tags = await ExifReader.load(image);
-
-    // Description
-    if (tags.description?.description) return tags.description.description;
-
-    // ImageDescription
-    if (tags.ImageDescription?.description) return tags.ImageDescription.description;
-
-    // UserComment
-    if (
-      tags.UserComment &&
-      typeof tags.UserComment === 'object' &&
-      tags.UserComment !== null &&
-      'description' in tags.UserComment
-    ) {
-      return (tags.UserComment as { description: string }).description;
-    }
-
-    // ExtDescrAccessibility
-    if (tags.ExtDescrAccessibility?.description) return tags.ExtDescrAccessibility.description;
-
-    // Caption/Abstract
-    if (tags['Caption/Abstract']?.description) return tags['Caption/Abstract'].description;
-
-    // XP Title
-    if (tags.XPTitle?.description) return tags.XPTitle.description;
-
-    // XP Comment
-    if (tags.XPComment?.description) return tags.XPComment.description;
-  } catch {
-    return undefined;
-  }
 }
 
 /**

--- a/gallery/tests/images.test.ts
+++ b/gallery/tests/images.test.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
-import { getImageDescription } from '../src/utils/image';
+import { getImageDescription } from '../src/utils/descriptions';
 
 const fixturesPath = path.resolve(process.cwd(), 'tests', 'fixtures', 'images');
 

--- a/gallery/tsup.config.ts
+++ b/gallery/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/lib/index.ts'],
+  entry: ['src/index.ts', 'src/lib/index.ts', 'src/lib/browser.ts'],
   format: ['esm', 'cjs'],
   dts: true,
   splitting: false,


### PR DESCRIPTION
This PR exports the `getImageDescription` function in a browser only context and allows a File object to be used as input along with a file path

Resolves #111 