### PR TITLE
[codex] Add gallery smoke test

### DIFF
--- a/gallery/tests/smoke.test.ts
+++ b/gallery/tests/smoke.test.ts
@@ -1,0 +1,78 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import { GalleryDataSchema, MediaFileSchema, ThumbnailSchema } from '@simple-photo-gallery/common';
+import { copySync } from 'fs-extra';
+
+const fixturePath = path.resolve(process.cwd(), 'tests', 'fixtures', 'single');
+const modernThemePath = path.resolve(process.cwd(), '..', 'themes', 'modern');
+const tsxPath = path.resolve(process.cwd(), '..', 'node_modules', '.bin', 'tsx');
+const cliPath = path.resolve(process.cwd(), 'src', 'index.ts');
+const MediaFileWithThumbnailSchema = MediaFileSchema.extend({
+  thumbnail: ThumbnailSchema,
+});
+
+function runCliCommand(args: string[]): void {
+  execFileSync(tsxPath, [cliPath, ...args], {
+    env: { ...process.env, SPG_TELEMETRY_PROVIDER: 'none' },
+    stdio: 'pipe',
+  });
+}
+
+describe('gallery smoke flow', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'spg-smoke-'));
+    copySync(fixturePath, tempDir);
+  });
+
+  afterEach(() => {
+    if (existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('initializes, thumbnails, builds, and renders expected HTML attributes', () => {
+    runCliCommand(['init', '--photos', tempDir, '--default']);
+    runCliCommand(['thumbnails', '--gallery', tempDir]);
+    runCliCommand(['build', '--gallery', tempDir, '--theme', modernThemePath]);
+
+    const galleryJsonPath = path.join(tempDir, 'gallery', 'gallery.json');
+    const galleryData = GalleryDataSchema.parse(JSON.parse(readFileSync(galleryJsonPath, 'utf8')));
+
+    expect(galleryData.sections).toHaveLength(1);
+    expect(galleryData.sections[0].images).toHaveLength(3);
+    expect(galleryData.metadata.image).toBe('/gallery/images/social-media-card.jpg');
+
+    for (const image of galleryData.sections[0].images) {
+      expect(() => MediaFileWithThumbnailSchema.parse(image)).not.toThrow();
+      expect(existsSync(path.join(tempDir, 'gallery', 'images', image.thumbnail!.path))).toBe(true);
+      expect(existsSync(path.join(tempDir, 'gallery', 'images', image.thumbnail!.pathRetina))).toBe(true);
+    }
+
+    expect(existsSync(path.join(tempDir, 'gallery', 'images', 'social-media-card.jpg'))).toBe(true);
+    expect(existsSync(path.join(tempDir, 'gallery', '_build'))).toBe(false);
+
+    const htmlPath = path.join(tempDir, 'index.html');
+    expect(existsSync(htmlPath)).toBe(true);
+
+    const html = readFileSync(htmlPath, 'utf8');
+    expect(html).toContain('<title>My Gallery</title>');
+    expect(html).toContain('class="gallery-section__item"');
+    expect(html).toContain('data-pswp-type="image"');
+    expect(html).toContain('srcset="gallery/images/img_1.avif 1x, gallery/images/img_1@2x.avif 2x"');
+    expect(html).not.toContain('undefined');
+
+    for (const image of galleryData.sections[0].images) {
+      expect(html).toContain(`data-image-id="${image.filename}"`);
+      expect(html).toContain(`href="${image.filename}"`);
+      expect(html).toContain(`data-pswp-src="${image.filename}"`);
+      expect(html).toContain(`data-pswp-width="${image.width}"`);
+      expect(html).toContain(`data-pswp-height="${image.height}"`);
+    }
+  });
+});

--- a/themes/modern/src/features/themes/base-theme/layouts/MainHead.astro
+++ b/themes/modern/src/features/themes/base-theme/layouts/MainHead.astro
@@ -34,6 +34,9 @@ const portraitPreloadSrcset = portraitAvifSrcset || portraitJpgSrcset;
 const portraitPreloadType = portraitAvifSrcset ? 'image/avif' : 'image/jpeg';
 const landscapePreloadSrcset = landscapeAvifSrcset || landscapeJpgSrcset;
 const landscapePreloadType = landscapeAvifSrcset ? 'image/avif' : 'image/jpeg';
+
+const metadataImageWidth = metadata?.imageWidth === undefined ? '1200' : String(metadata.imageWidth);
+const metadataImageHeight = metadata?.imageHeight === undefined ? '631' : String(metadata.imageHeight);
 ---
 
 <head>
@@ -55,8 +58,8 @@ const landscapePreloadType = landscapeAvifSrcset ? 'image/avif' : 'image/jpeg';
   <meta property="og:title" content={title} />
   <meta property="og:description" content={description} />
   {metadata?.image && <meta property="og:image" content={metadata.image} />}
-  <meta property="og:image:width" content={String(metadata?.imageWidth) || '1200'} />
-  <meta property="og:image:height" content={String(metadata?.imageHeight) || '631'} />
+  <meta property="og:image:width" content={metadataImageWidth} />
+  <meta property="og:image:height" content={metadataImageHeight} />
   {metadata?.ogType && <meta property="og:type" content={metadata.ogType} />}
   {metadata?.ogUrl || (url && <meta property="og:url" content={metadata?.ogUrl || url} />)}
   {metadata?.ogSiteName && <meta property="og:site_name" content={metadata.ogSiteName} />}
@@ -66,8 +69,8 @@ const landscapePreloadType = landscapeAvifSrcset ? 'image/avif' : 'image/jpeg';
   <meta name="twitter:title" content={title} />
   <meta name="twitter:description" content={description} />
   {metadata?.image && <meta name="twitter:image" content={metadata.image} />}
-  <meta name="twitter:image:width" content={String(metadata?.imageWidth) || '1200'} />
-  <meta name="twitter:image:height" content={String(metadata?.imageHeight) || '631'} />
+  <meta name="twitter:image:width" content={metadataImageWidth} />
+  <meta name="twitter:image:height" content={metadataImageHeight} />
   {metadata?.twitterSite && <meta name="twitter:site" content={metadata.twitterSite} />}
   {metadata?.twitterCreator && <meta name="twitter:creator" content={metadata.twitterCreator} />}
 


### PR DESCRIPTION
## Summary

- Adds an end-to-end smoke test that runs the real CLI init, thumbnails, and build commands against a fixture gallery.
- Verifies gallery.json, thumbnails, social card output, generated index.html, and key lightbox/image attributes inside the HTML.
- Fixes social image dimension fallbacks so generated metadata does not render content="undefined".

## Validation

- yarn workspace @simple-photo-gallery/common build
- yarn workspace simple-photo-gallery test smoke.test.ts
- yarn workspace @simple-photo-gallery/theme-modern lint && yarn workspace @simple-photo-gallery/theme-modern format
